### PR TITLE
Invoke Strict Mode

### DIFF
--- a/devicetest.js
+++ b/devicetest.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var SerialPort = require("serialport");
 
 // enter in just the command you want to test  (the complete api  command will be built)


### PR DESCRIPTION
Add use strict to devicetest.js to enable backwards compatibility on older node versions.  Tested on node 4.3.1 on mac and 4.2.1 on Pocket C.H.I.P.  This was all that prevented the app from running on these versions.